### PR TITLE
Fixed FlipCamera

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerFlipCamera.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerFlipCamera.cpp
@@ -1,5 +1,5 @@
 /*
-	Effect by DrUnderscore (James)
+	Effect by DrUnderscore (James), modified by Last0xygen
 */
 
 #include <stdafx.h>
@@ -19,23 +19,21 @@ static void UpdateCamera()
 static void OnStart()
 {
     flippedCamera = CAM::CREATE_CAM("DEFAULT_SCRIPTED_CAMERA", 1);
-    CAM::SET_CAM_ACTIVE(flippedCamera, true);
-    UpdateCamera();
-    CAM::RENDER_SCRIPT_CAMS(true, 0, 3000, 1, 0, 0);
+    CAM::RENDER_SCRIPT_CAMS(true, true, 700, 1, 1, 1);
 }
 
 static void OnTick()
 {
+    CAM::SET_CAM_ACTIVE(flippedCamera, true);
     UpdateCamera();
 }
 
-static void OnEnd()
+static void OnStop()
 {
     CAM::SET_CAM_ACTIVE(flippedCamera, false);
-    CAM::RENDER_SCRIPT_CAMS(false, 0, 3000, 1, 0, 0);
-    CAM::DESTROY_CAM(flippedCamera, false);
-
+    CAM::RENDER_SCRIPT_CAMS(false, true, 700, 1, 1, 1);
+    CAM::DESTROY_CAM(flippedCamera, true);
     flippedCamera = 0;
 }
 
-static RegisterEffect registerEffect(EFFECT_FLIP_CAMERA, OnStart, OnEnd, OnTick);
+static RegisterEffect registerEffect(EFFECT_FLIP_CAMERA, OnStart, OnStop, OnTick);


### PR DESCRIPTION
Those bools on RENDER_SCRIPT_CAMS seems to be "true" to be able to switch back
Also enabled the animation between the cameras.
Setting the camera as active camera on tick to prevent any bugs with new cams being created while  this effect is on.
There still is the "bug", that anything that normally draws on the gameplay cam will now not work (sniper-scope, target dot...)